### PR TITLE
Add URL-based remote move planning

### DIFF
--- a/map.html
+++ b/map.html
@@ -167,8 +167,7 @@
         board:{width,height,food:foods,snakes:snakes.map(s=>({id:s.key,name:s.key,health:100,body:s.body}))},
         you:{id:sn.key,name:sn.key,health:100,body:sn.body}
       };
-      const proxyUrl = 'https://corsproxy.io/?';
-      fetch(proxyUrl + encodeURIComponent(url),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
+      fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
         .then(r=>r.json()).then(res=>{
           const dir=res.move;
           const dirs={up:{x:0,y:-1},down:{x:0,y:1},left:{x:-1,y:0},right:{x:1,y:0}};

--- a/map.html
+++ b/map.html
@@ -167,7 +167,8 @@
         board:{width,height,food:foods,snakes:snakes.map(s=>({id:s.key,name:s.key,health:100,body:s.body}))},
         you:{id:sn.key,name:sn.key,health:100,body:sn.body}
       };
-      fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
+      const proxyUrl = 'https://corsproxy.io/?';
+      fetch(proxyUrl + encodeURIComponent(url),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
         .then(r=>r.json()).then(res=>{
           const dir=res.move;
           const dirs={up:{x:0,y:-1},down:{x:0,y:1},left:{x:-1,y:0},right:{x:1,y:0}};

--- a/map.html
+++ b/map.html
@@ -56,6 +56,10 @@
     <textarea id="importData" rows="5" placeholder="Paste JSON here"></textarea><br/>
     <button id="importBtn">Import JSON</button>
   </div>
+  <div style="margin-top:20px;">
+    <h3>Network Log</h3>
+    <pre id="networkLog" style="max-height:150px;overflow:auto;background:#f8f8f8;border:1px solid #ccc;padding:10px;"></pre>
+  </div>
   <script>
     let width, height;
     let snakes = [], foods = [], history = [], snapshots = [];
@@ -71,6 +75,26 @@
     const sliderLabel = document.getElementById('sliderLabel');
     const urlSelect = document.getElementById('urlSnakeSelect');
     const urlInput = document.getElementById('snakeUrlInput');
+    const networkLog = document.getElementById('networkLog');
+
+    function logNetwork(...args){
+      const line = args.map(a=>typeof a==='string'?a:JSON.stringify(a)).join(' ');
+      networkLog.textContent += line+'\n';
+      networkLog.scrollTop = networkLog.scrollHeight;
+      console.log(...args);
+    }
+
+    const originalFetch = window.fetch;
+    window.fetch = function(resource, options){
+      logNetwork('Request:', resource, options||{});
+      return originalFetch(resource, options).then(res=>{
+        logNetwork('Response:', res.status, res.statusText, 'from', resource);
+        return res;
+      }).catch(err=>{
+        logNetwork('Error:', err, 'from', resource);
+        throw err;
+      });
+    };
 
     // Setup toolbar buttons
     const snakeButtonsContainer = document.getElementById('snakeButtons');
@@ -168,7 +192,8 @@
         you:{id:sn.key,name:sn.key,health:100,body:sn.body}
       };
       fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
-        .then(r=>r.json()).then(res=>{
+        .then(r=>{if(!r.ok) throw new Error('HTTP '+r.status); return r.json();})
+        .then(res=>{
           const dir=res.move;
           const dirs={up:{x:0,y:-1},down:{x:0,y:1},left:{x:-1,y:0},right:{x:1,y:0}};
           if(dirs[dir]){
@@ -179,7 +204,10 @@
             render();
             updateToolbar();
           }
-        }).catch(()=>alert('Fetch failed for '+key));
+        }).catch(err=>{
+          logNetwork('Fetch failed for', key, err);
+          alert('Fetch failed for '+key);
+        });
     }
 
     function createBoard(fromImport){

--- a/map.html
+++ b/map.html
@@ -26,6 +26,11 @@
     <label>Height: <input id="height" type="number" min="2" value="11"></label>
     <button id="createBoard">Create Board</button>
   </div>
+  <div>
+    <select id="urlSnakeSelect"></select>
+    <input id="snakeUrlInput" type="text" placeholder="Snake URL" />
+    <button id="setUrlBtn">Set URL</button>
+  </div>
   <div id="toolbar">
     <label><input type="checkbox" id="delayedGrowthCheckbox" checked/> Delayed Growth</label>
     <span>Place Snake A–L:</span>
@@ -55,6 +60,7 @@
     let width, height;
     let snakes = [], foods = [], history = [], snapshots = [];
     let viewTurn = 0, selectedTool = null;
+    const snakeUrls = {};
     const cellSize = 30;
     const snakeColors = ['#4caf50','#2196f3','#ff9800','#9c27b0','#795548','#009688','#e91e63','#00bcd4','#ff5722','#607d8b','#cddc39','#3f51b5'];
     const snakeLetters = 'ABCDEFGHIJKL'.split('');
@@ -63,20 +69,39 @@
     const overlay = document.getElementById('overlay');
     const historySlider = document.getElementById('historySlider');
     const sliderLabel = document.getElementById('sliderLabel');
+    const urlSelect = document.getElementById('urlSnakeSelect');
+    const urlInput = document.getElementById('snakeUrlInput');
 
     // Setup toolbar buttons
     const snakeButtonsContainer = document.getElementById('snakeButtons');
+    const snakeButtonElems = {};
     snakeLetters.forEach(key => {
+      const opt = document.createElement('option');
+      opt.value = key; opt.textContent = key;
+      urlSelect.appendChild(opt);
+
+      const span = document.createElement('span');
+      span.dataset.key = key;
       const btn = document.createElement('button');
       btn.textContent = key;
       btn.className = 'tool-button'; btn.dataset.type = 'snake'; btn.dataset.key = key;
       btn.addEventListener('click', ()=>selectTool({type:'snake',key}));
-      snakeButtonsContainer.appendChild(btn);
+      span.appendChild(btn);
+      snakeButtonsContainer.appendChild(span);
+      snakeButtonElems[key] = span;
     });
     document.getElementById('foodButton').addEventListener('click', ()=>selectTool({type:'food'}));
     document.getElementById('eraseButton').addEventListener('click', ()=>selectTool({type:'erase'}));
     document.getElementById('moveTool').addEventListener('click', ()=>selectTool({type:'plan'}));
     document.getElementById('tickBtn').addEventListener('click', applyMoves);
+    document.getElementById('setUrlBtn').addEventListener('click', ()=>{
+      const key = urlSelect.value;
+      const url = urlInput.value.trim();
+      if(url) snakeUrls[key] = url; else delete snakeUrls[key];
+      const sn = snakes.find(s=>s.key===key);
+      if(sn) sn.url = url || undefined;
+      updateFetchButtons();
+    });
 
     historySlider.addEventListener('input', ()=>{
       viewTurn = +historySlider.value;
@@ -86,20 +111,22 @@
 
     document.getElementById('createBoard').addEventListener('click', ()=>createBoard(false));
     document.getElementById('exportBtn').addEventListener('click', ()=>{
-      const data = { width, height, snakes:snakes.map(s=>({body:s.body,key:s.key,color:s.color})), foods, history };
+      const data = { width, height, snakes:snakes.map(s=>({body:s.body,key:s.key,color:s.color,url:s.url})), foods, history };
       document.getElementById('exportData').value = JSON.stringify(data,null,2);
     });
     document.getElementById('importBtn').addEventListener('click', ()=>{
       try{
         const data = JSON.parse(document.getElementById('importData').value);
         width=data.width; height=data.height;
-        snakes = data.snakes.map((sn,i)=>({id:i,body:sn.body,key:sn.key,color:sn.color,lastDir:null}));
+        snakes = data.snakes.map((sn,i)=>({id:i,body:sn.body,key:sn.key,color:sn.color,lastDir:null,url:sn.url}));
+        snakes.forEach(sn=>{ if(sn.url) snakeUrls[sn.key]=sn.url; });
         foods=data.foods||[]; history=data.history||[];
         snapshots=[]; createBoard(true);
         history.forEach(turn=>applyHistoryTurn(turn));
         viewTurn=history.length;
         historySlider.max=viewTurn; historySlider.value=viewTurn;
         sliderLabel.textContent=`Turn: ${viewTurn}`;
+        updateFetchButtons();
       }catch(e){alert('Invalid JSON');}
     });
 
@@ -109,6 +136,48 @@
         const type=btn.dataset.type, key=btn.dataset.key;
         btn.classList.toggle('active', selectedTool && selectedTool.type===type && (!key||selectedTool.key===key));
       });
+      updateFetchButtons();
+    }
+
+    function updateFetchButtons(){
+      snakeLetters.forEach(key=>{
+        const span = snakeButtonElems[key];
+        let fb = span.querySelector('.fetchBtn');
+        if(snakeUrls[key] && snakes.some(s=>s.key===key)){
+          if(!fb){
+            fb = document.createElement('button');
+            fb.textContent = 'fetch';
+            fb.className = 'tool-button fetchBtn';
+            fb.addEventListener('click', ()=>fetchMove(key));
+            span.appendChild(fb);
+          }
+        }else if(fb){
+          fb.remove();
+        }
+      });
+    }
+
+    function fetchMove(key){
+      const sn = snakes.find(s=>s.key===key);
+      const url = snakeUrls[key];
+      if(!sn || !url) return;
+      const state = {
+        game:{id:'1'},
+        turn:history.length,
+        board:{width,height,food:foods,snakes:snakes.map(s=>({id:s.key,name:s.key,health:100,body:s.body}))},
+        you:{id:sn.key,name:sn.key,health:100,body:sn.body}
+      };
+      fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(state)})
+        .then(r=>r.json()).then(res=>{
+          const dir=res.move;
+          const dirs={up:{x:0,y:-1},down:{x:0,y:1},left:{x:-1,y:0},right:{x:1,y:0}};
+          if(dirs[dir]){
+            const head=sn.body[0];
+            sn.next={x:head.x+dirs[dir].x,y:head.y+dirs[dir].y};
+            sn.lastDir=dirs[dir];
+            render();
+          }
+        }).catch(()=>alert('Fetch failed for '+key));
     }
 
     function createBoard(fromImport){
@@ -130,9 +199,10 @@
       overlay.width=W; overlay.height=H;
       overlay.style.width=W+'px'; overlay.style.height=H+'px';
       gridContainer.style.width=W+'px'; gridContainer.style.height=H+'px';
-      snapshots=[snapshotState()];
-      render();
-    }
+        snapshots=[snapshotState()];
+        render();
+        updateFetchButtons();
+      }
 
     function snapshotState(){
       return{
@@ -257,6 +327,7 @@
       snapshots.push(snapshotState());
       viewTurn=history.length;historySlider.max=viewTurn;historySlider.value=viewTurn;sliderLabel.textContent=`Turn: ${viewTurn}`;
       render();
+      updateFetchButtons();
     }
 
     // Initial

--- a/map.html
+++ b/map.html
@@ -174,9 +174,11 @@
           const dirs={up:{x:0,y:-1},down:{x:0,y:1},left:{x:-1,y:0},right:{x:1,y:0}};
           if(dirs[dir]){
             const head=sn.body[0];
-            sn.next={x:head.x+dirs[dir].x,y:head.y+dirs[dir].y};
-            sn.lastDir=dirs[dir];
+            const move=dirs[dir];
+            sn.next={x:head.x+move.x,y:head.y+move.y};
+            sn.lastDir={dx:move.x,dy:move.y};
             render();
+            updateToolbar();
           }
         }).catch(()=>alert('Fetch failed for '+key));
     }


### PR DESCRIPTION
## Summary
- allow setting URLs per snake via dropdown and text field
- add fetch buttons for snakes with URLs to auto-plan moves
- include URLs in export/import data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef4fd4e6c832fbac491727445637b